### PR TITLE
fixing the private flag

### DIFF
--- a/src/main/java/com/cx/plugin/cli/utils/CxConfigHelper.java
+++ b/src/main/java/com/cx/plugin/cli/utils/CxConfigHelper.java
@@ -71,7 +71,7 @@ public final class CxConfigHelper {
         scanConfig.setUseSSOLogin(cmd.hasOption(IS_SSO));
         scanConfig.setDisableCertificateValidation(cmd.hasOption(TRUSTED_CERTIFICATES));
 
-        scanConfig.setPublic(cmd.hasOption(IS_PRIVATE));
+        scanConfig.setPublic(!cmd.hasOption(IS_PRIVATE));
         scanConfig.setEnablePolicyViolations(cmd.hasOption(IS_CHECKED_POLICY));
         scanConfig.setProjectName(extractProjectName(cmd.getOptionValue(FULL_PROJECT_PATH)));
         scanConfig.setTeamPath(extractTeamPath(cmd.getOptionValue(FULL_PROJECT_PATH)));


### PR DESCRIPTION
the flag had flipped logic, when there was no private flag the scan would be set to private and when we had the private flag the scan was set to public. flipped the logic so, when we have the private flag the scan would be set to private and vice versa 