### PR TITLE
removed dependencies and put them in the common instead to remove the…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,18 +132,19 @@
         <dependency>
             <groupId>com.checkmarx</groupId>
             <artifactId>cx-client-common</artifactId>
-            <version>2020.1.13.SCA</version>
+            <version>2020.2.2.SCA</version>
         </dependency>
-        <dependency>
+        <!-- those dependencies were implemented in the common, to solve a log4j warning -->
+<!--        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
             <version>1.7.21</version>
-        </dependency>
-        <dependency>
+        </dependency>-->
+<!--        <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
             <version>1.2.17</version>
-        </dependency>
+        </dependency>-->
         <dependency>
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>


### PR DESCRIPTION
… warning, and solved the bash script, changed its EOL encoding so it works on linux. [AB#256](https://dev.azure.com/CxSDLC/fc0b9449-79c8-4ff2-bd04-b9e18cf01a53/_workitems/edit/256) and [AB#689](https://dev.azure.com/CxSDLC/fc0b9449-79c8-4ff2-bd04-b9e18cf01a53/_workitems/edit/689) . raised the version to 2020.2.2.SCA