### PR TITLE
used latest cx common client version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.cx.plugin</groupId>
     <artifactId>CxConsolePlugin</artifactId>
-    <version>1.1.7</version>
+    <version>1.1.8</version>
     <packaging>jar</packaging>
 
     <repositories>
@@ -133,7 +133,7 @@
         <dependency>
             <groupId>com.checkmarx</groupId>
             <artifactId>cx-client-common</artifactId>
-            <version>2021.3.166</version>
+            <version>2021.3.171</version>
             <!-- Remove these excludes once latest FSA is used -->
            <exclusions>
 	     	<exclusion>


### PR DESCRIPTION
Bug - 2833

Used latest common version 2021.3.171 . Issue was due to retrieving access token once again in 2021.3.167 for other fix which was fixed in 2021.3.171 version. 