### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,14 @@
             <version>2021.4.9</version>
             <!-- Remove these excludes once latest FSA is used -->
            <exclusions>
+		   <exclusion>
+	     		<groupId>org.freemarker</groupId>
+				<artifactId>freemarker</artifactId>
+           	</exclusion>
+			<exclusion>
+	     		<groupId>com.github.junrar</groupId>
+				<artifactId>junrar</artifactId>
+           	</exclusion>
 	     	<exclusion>
 	     		<groupId>org.mozilla</groupId>
            		<artifactId>rhino</artifactId>
@@ -151,6 +159,22 @@
 	      </exclusions>
         </dependency>
         <!-- excluded dependencies from cx-client-common -->
+		<dependency>
+			<groupId>com.github.junrar</groupId>
+			<artifactId>junrar</artifactId>
+			<version>7.4.1</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-api</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.freemarker</groupId>
+			<artifactId>freemarker</artifactId>
+			<version>2.3.31</version>
+		</dependency>
         <dependency>
         	<groupId>org.mozilla</groupId>
            	<artifactId>rhino</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.cx.plugin</groupId>
     <artifactId>CxConsolePlugin</artifactId>
-    <version>1.1.10</version>
+    <version>1.1.11</version>
     <packaging>jar</packaging>
 
     <repositories>
@@ -132,7 +132,7 @@
         <dependency>
             <groupId>com.checkmarx</groupId>
             <artifactId>cx-client-common</artifactId>
-            <version>2021.4.9</version>
+            <version>2022.1.10</version>
             <!-- Remove these excludes once latest FSA is used -->
            <exclusions>
 		   <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -151,11 +151,23 @@
            		<groupId>io.vertx</groupId>
            		<artifactId>vertx-web</artifactId>
            	</exclusion>
-         
-               <exclusion>
-                   <groupId>ch.qos.logback</groupId>
-                   <artifactId>logback-classic</artifactId>
+            <exclusion>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+            </exclusion>
+			<exclusion>
+                   <groupId>io.netty</groupId>
+					<artifactId>netty-codec-http</artifactId>
                </exclusion>
+			   <exclusion>
+                   <groupId>com.fasterxml.jackson.core</groupId>
+					<artifactId>jackson-databind</artifactId>
+               </exclusion>
+			   <exclusion>
+                   <groupId>org.springframework</groupId>
+					<artifactId>spring-core</artifactId>
+               </exclusion>
+			   
 	      </exclusions>
         </dependency>
         <!-- excluded dependencies from cx-client-common -->
@@ -174,6 +186,21 @@
 			<groupId>org.freemarker</groupId>
 			<artifactId>freemarker</artifactId>
 			<version>2.3.31</version>
+		</dependency>
+		<dependency>
+			<groupId>io.netty</groupId>
+			<artifactId>netty-codec-http</artifactId>
+			<version>4.1.75.Final</version>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>2.13.2.1</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-core</artifactId>
+			<version>5.3.17</version>
 		</dependency>
         <dependency>
         	<groupId>org.mozilla</groupId>
@@ -248,11 +275,6 @@
             	<artifactId>log4j-slf4j-impl</artifactId>
 	     	</exclusion>	     		     	
 	     	</exclusions>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>2.10.5.1</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>


### PR DESCRIPTION
We have found Vulnerability for four below jars
1.	org.simpleframework:simple-xml
2.	org.apache.velocity:velocity
3.	org.freemarker:freemarker
4.	com.github.junrar:junrar

Out off first and second are already on latest version, so we have updated for 3rd (“org.freemarker:freemarker”) and 4th (“com.github.junrar:junrar”) jar file to 2.3.31 and 7.4.1 respectively

After updating  jar (“org.freemarker:freemarker”) and (“com.github.junrar:junrar”) to latest version they are stop reporting Vulnerability

By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](https://github.com/checkmarx-ltd/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/checkmarx-ltd/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

> Describe the purpose of this PR along with any background information and the impacts of the proposed change.

### References

> Include supporting link to GitHub Issue/PR number

### Testing

> Describe how this change was tested. Be specific about anything not tested and reasons why. If this solution has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentaiton is a Wiki Update, please indicate desired changes within PR MD Comment*
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used
