### PR TITLE
Duplicate headers while re-attempting the scan for token expired case ( PLUG-256)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.cx.plugin</groupId>
     <artifactId>CxConsolePlugin</artifactId>
-    <version>1.1.13</version>
+    <version>1.1.14</version>
     <packaging>jar</packaging>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
         <dependency>
             <groupId>com.checkmarx</groupId>
             <artifactId>cx-client-common</artifactId>
-            <version>2022.2.12</version>
+            <version>2022.2.14</version>
             <!-- Remove these excludes once latest FSA is used -->
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
### Description

This PR fixes PLUG-256 where duplicate headers were sent during the retry attempt when token expires for a long running scan.

### References

PLUG-256

### Testing

Private build had been shared with the customer where this was tested.

### Checklist

- [X ] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentaiton is a Wiki Update, please indicate desired changes within PR MD Comment*
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used
