### PR TITLE
Making the scan type full when both incremental and force scan set to true

### DIFF
--- a/src/main/java/com/cx/plugin/cli/utils/CxConfigHelper.java
+++ b/src/main/java/com/cx/plugin/cli/utils/CxConfigHelper.java
@@ -192,9 +192,12 @@ public final class CxConfigHelper {
 		}
         
         if (cmd.hasOption(IS_INCREMENTAL)) {
-        	scanConfig.setIncremental(cmd.hasOption(IS_INCREMENTAL));
+        	scanConfig.setIncremental(cmd.hasOption(IS_INCREMENTAL) && (!cmd.hasOption(IS_FORCE_SCAN)));
         }
-        
+        boolean isFullScan = (cmd.hasOption(IS_INCREMENTAL)) && (cmd.hasOption(IS_FORCE_SCAN));
+        if(isFullScan) {
+        	log.info("Configuration is set to incremental true and force scan true, hence the scan will be full.");
+        }
 		if (cmd.hasOption(PERIODIC_FULL_SCAN)) {
 			if (!cmd.hasOption(IS_INCREMENTAL)) {
 				getRequiredParam(cmd, IS_INCREMENTAL, null);

--- a/src/main/java/com/cx/plugin/cli/utils/CxConfigHelper.java
+++ b/src/main/java/com/cx/plugin/cli/utils/CxConfigHelper.java
@@ -192,11 +192,11 @@ public final class CxConfigHelper {
 		}
         
         if (cmd.hasOption(IS_INCREMENTAL)) {
-        	scanConfig.setIncremental(cmd.hasOption(IS_INCREMENTAL) && (!cmd.hasOption(IS_FORCE_SCAN)));
+        	scanConfig.setIncremental(!cmd.hasOption(IS_FORCE_SCAN));
         }
         boolean isFullScan = (cmd.hasOption(IS_INCREMENTAL)) && (cmd.hasOption(IS_FORCE_SCAN));
         if(isFullScan) {
-        	log.info("Configuration is set to incremental true and force scan true, hence the scan will be full.");
+        	log.info("Both incremental scan and Force scan options are provided. Full scan will be performed.");
         }
 		if (cmd.hasOption(PERIODIC_FULL_SCAN)) {
 			if (!cmd.hasOption(IS_INCREMENTAL)) {


### PR DESCRIPTION
Fix for plug - 1007, if both ( -Incremental and -ForceScan)  parameters are set TRUE, the scan will be full.
We are logging a message in the log regarding the same to inform user.

