### PR TITLE
Vulnerability fix and Force scan when both incremental and force scan configured.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.cx.plugin</groupId>
     <artifactId>CxConsolePlugin</artifactId>
-    <version>1.1.19</version>
+    <version>1.1.20</version>
     <packaging>jar</packaging>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -256,7 +256,7 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-web</artifactId>
-            <version>4.0.2</version>
+            <version>4.3.8</version>
             <exclusions>
                 <exclusion>
                     <groupId>io.netty</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.cx.plugin</groupId>
     <artifactId>CxConsolePlugin</artifactId>
-    <version>1.1.20</version>
+    <version>1.1.21</version>
     <packaging>jar</packaging>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.cx.plugin</groupId>
     <artifactId>CxConsolePlugin</artifactId>
-    <version>1.1.18</version>
+    <version>1.1.19</version>
     <packaging>jar</packaging>
 
     <repositories>
@@ -135,7 +135,22 @@
             <version>2022.4.4</version>
             <!-- Remove these excludes once latest FSA is used -->
             <exclusions>
+				<exclusion>
+				    <groupId>com.google.guava</groupId>
+				    <artifactId>guava</artifactId>
+				</exclusion>
+				<exclusion>
+                    <groupId>com.google.collections</groupId>
+                    <artifactId>google-collections</artifactId>
+                </exclusion>
+                
                 <exclusion>
+				    <groupId>org.json</groupId>
+    				<artifactId>json</artifactId>
+				</exclusion>
+				
+                <exclusion>
+		
                     <groupId>org.freemarker</groupId>
                     <artifactId>freemarker</artifactId>
                 </exclusion>
@@ -190,6 +205,18 @@
             </exclusions>
         </dependency>
         <!-- excluded dependencies from cx-client-common -->
+        <dependency>
+				<groupId>org.json</groupId>
+				<artifactId>json</artifactId>
+				<version>20220924</version>
+			</dependency>
+			<dependency>
+			    <groupId>com.google.guava</groupId>
+			    <artifactId>guava</artifactId>
+			    <version>31.1-jre</version>
+			</dependency>
+			
+			
         <dependency>
             <groupId>com.github.junrar</groupId>
             <artifactId>junrar</artifactId>
@@ -297,6 +324,7 @@
                     <groupId>commons-io</groupId>
                     <artifactId>commons-io</artifactId>
                 </exclusion>
+                
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>jackson-databind</artifactId>

--- a/src/main/java/com/cx/plugin/cli/utils/CxConfigHelper.java
+++ b/src/main/java/com/cx/plugin/cli/utils/CxConfigHelper.java
@@ -192,9 +192,12 @@ public final class CxConfigHelper {
 		}
         
         if (cmd.hasOption(IS_INCREMENTAL)) {
-        	scanConfig.setIncremental(cmd.hasOption(IS_INCREMENTAL));
+        	scanConfig.setIncremental(!cmd.hasOption(IS_FORCE_SCAN));
         }
-        
+        boolean isFullScan = (cmd.hasOption(IS_INCREMENTAL)) && (cmd.hasOption(IS_FORCE_SCAN));
+        if(isFullScan) {
+        	log.info("Both incremental scan and Force scan options are provided. Full scan will be performed.");
+        }
 		if (cmd.hasOption(PERIODIC_FULL_SCAN)) {
 			if (!cmd.hasOption(IS_INCREMENTAL)) {
 				getRequiredParam(cmd, IS_INCREMENTAL, null);


### PR DESCRIPTION
This release includes 
1. vulnerability fixes which led to upgrade of below libraries.
com.google.guava:guava to 31.1-jre
org.json : json to 20220924
io.vertx: vertx-web to 4.3.8

2. Fixed the issue where scan was happening incremental instead of full scan when incremental and force scan both are configured.
