### PR TITLE
Implemented Post Scan Action

### DIFF
--- a/src/main/java/com/cx/plugin/cli/constants/ArgDescriptions.java
+++ b/src/main/java/com/cx/plugin/cli/constants/ArgDescriptions.java
@@ -154,6 +154,8 @@ class ArgDescriptions {
     static final String ENABLE_SAST_BRANCHING = "Enable to create child project";
     static final String MASTER_BRANCH_PROJ_NAME = "Master branch project name";
 
+    static final String POST_SCAN_ACTION = "Post Scan Action name that is to be performed automatically after a scan.";
+    
     static final String PERIODIC_FULL_SCAN = "Run a full scan after X incremental scans . Scans all files, (-Incremental should be enable). Optional.";    
 
 }

--- a/src/main/java/com/cx/plugin/cli/constants/Command.java
+++ b/src/main/java/com/cx/plugin/cli/constants/Command.java
@@ -179,6 +179,8 @@ public enum Command {
 
         options.addOption(ENABLE_SAST_BRANCHING, false, ArgDescriptions.ENABLE_SAST_BRANCHING);
         options.addOption(MASTER_BRANCH_PROJ_NAME, true, ArgDescriptions.MASTER_BRANCH_PROJ_NAME);
+        
+        options.addOption(POST_SCAN_ACTION, true, ArgDescriptions.POST_SCAN_ACTION);
 
         options.addOption(PERIODIC_FULL_SCAN, true, ArgDescriptions.PERIODIC_FULL_SCAN);
 

--- a/src/main/java/com/cx/plugin/cli/constants/Parameters.java
+++ b/src/main/java/com/cx/plugin/cli/constants/Parameters.java
@@ -117,7 +117,7 @@ public final class Parameters {
     public static final String ENABLE_SAST_BRANCHING = "enablesastbranching";
     public static final String MASTER_BRANCH_PROJ_NAME = "masterbranchprojname";
 
-    public static final String POST_SCAN_ACTION = "postscanactionid";
+    public static final String POST_SCAN_ACTION = "postscanaction";
 
     public static final String PERIODIC_FULL_SCAN = "periodicfullscan";
 

--- a/src/main/java/com/cx/plugin/cli/constants/Parameters.java
+++ b/src/main/java/com/cx/plugin/cli/constants/Parameters.java
@@ -117,6 +117,7 @@ public final class Parameters {
     public static final String ENABLE_SAST_BRANCHING = "enablesastbranching";
     public static final String MASTER_BRANCH_PROJ_NAME = "masterbranchprojname";
 
+    public static final String POST_SCAN_ACTION = "postscanactionid";
 
     public static final String PERIODIC_FULL_SCAN = "periodicfullscan";
 

--- a/src/main/java/com/cx/plugin/cli/utils/CxConfigHelper.java
+++ b/src/main/java/com/cx/plugin/cli/utils/CxConfigHelper.java
@@ -181,6 +181,8 @@ public final class CxConfigHelper {
         	throwForInvalidScaReportFormat(scanConfig.getScaReportFormat());
         
         scanConfig.setIncremental(cmd.hasOption(IS_INCREMENTAL));
+        String postScanAction = cmd.getOptionValue(POST_SCAN_ACTION);
+        	scanConfig.setPostScanName(postScanAction);
         scanConfig.setForceScan(cmd.hasOption(IS_FORCE_SCAN));        
 		scanConfig.setEnableSASTBranching(cmd.hasOption(ENABLE_SAST_BRANCHING));
 		if (cmd.hasOption(ENABLE_SAST_BRANCHING)) {


### PR DESCRIPTION
Test cases I had covered while testing regarding implementation of post scan action for plug 397 i.e. Implemented Post Scan Action:

1. post scan action parameter value should be present in logs.
2. on sast server post scan action should be assigned to project.
3. if we dont pass argument it should give error message
	[CxConsole] Error parsing command:
org.apache.commons.cli.MissingArgumentException: Missing argument for option: postScanActionId

4. if we pass wrong post scan name it should give following error message:
	com.cx.restclient.exception.CxClientException: Could not resolve post scan item ID from post scan action list: gmails
[2023-04-11T04:30:40,599 ERROR] CLI process terminated, error: com.cx.restclient.exception.CxClientException: Could not resolve post scan item ID from post scan action list: gmails