### PR TITLE
Add version checking

### DIFF
--- a/src/main/java/com/cx/plugin/cli/utils/CxConfigHelper.java
+++ b/src/main/java/com/cx/plugin/cli/utils/CxConfigHelper.java
@@ -1079,7 +1079,7 @@ public final class CxConfigHelper {
         log.info("--------------------");
 
         String pluginVersion = CxConfigHelper.class.getPackage()!=null ? CxConfigHelper.class.getPackage().getImplementationVersion() : "";
-        log.info("plugin version: {}", pluginVersion);
+        VersionChecker.checkForUpdates(pluginVersion);
         for (Option param : commandLine.getOptions()) {
             String name = param.getLongOpt() != null ? param.getLongOpt() : param.getOpt();
             String value;

--- a/src/main/java/com/cx/plugin/cli/utils/VersionChecker.java
+++ b/src/main/java/com/cx/plugin/cli/utils/VersionChecker.java
@@ -1,0 +1,90 @@
+package com.cx.plugin.cli.utils;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Scanner;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.json.JSONObject;
+
+public class VersionChecker {
+    private static final Logger log = LogManager.getLogger(VersionChecker.class);
+    private static final String API_URL = "https://api.github.com/repos/checkmarx-ltd/CLI/releases/latest";
+
+    public static void checkForUpdates(String currentVersion) {
+        if (currentVersion == null || currentVersion.isEmpty()) {
+            log.warn("Failed to determine the current version.");
+            return;
+        }
+        currentVersion = sanitizeVersion(currentVersion);
+
+        try {
+            String latestVersion = fetchLatestVersion();
+            if (latestVersion == null) {
+                log.warn("Failed to fetch the latest version.");
+                return;
+            }
+            latestVersion = sanitizeVersion(latestVersion);
+
+            log.info("Current version: {}", currentVersion);
+            log.info("Latest version: {}", latestVersion);
+
+            int comparison = compareVersions(currentVersion, latestVersion);
+            if (comparison < 0) {
+                log.warn("A new version is available: {}. Please visit checkmarx.com/plugins and download the latest version.", latestVersion);
+            } else {
+                log.info("You are running the latest version.");
+            }
+        } catch (IOException e) {
+            log.error("Error checking for updates: {}", e.getMessage());
+        }
+    }
+
+    private static String fetchLatestVersion() throws IOException {
+        URL url = new URL(API_URL);
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setRequestMethod("GET");
+        conn.setRequestProperty("Accept", "application/vnd.github.v3+json");
+
+        int responseCode = conn.getResponseCode();
+        if (responseCode != 200) {
+            log.error("Failed to fetch latest release. HTTP Response Code: {}", responseCode);
+            return null;
+        }
+
+        Scanner scanner = new Scanner(conn.getInputStream());
+        StringBuilder response = new StringBuilder();
+        while (scanner.hasNext()) {
+            response.append(scanner.nextLine());
+        }
+        scanner.close();
+
+        JSONObject json = new JSONObject(response.toString());
+        return json.optString("tag_name"); // GitHub releases store the version in "tag_name"
+    }
+
+    private static int compareVersions(String v1, String v2) {
+        String[] v1Parts = v1.split("\\.");
+        String[] v2Parts = v2.split("\\.");
+
+        int length = Math.max(v1Parts.length, v2Parts.length);
+        for (int i = 0; i < length; i++) {
+            int num1 = (i < v1Parts.length) ? Integer.parseInt(v1Parts[i]) : 0;
+            int num2 = (i < v2Parts.length) ? Integer.parseInt(v2Parts[i]) : 0;
+
+            if (num1 < num2) return -1;
+            if (num1 > num2) return 1;
+        }
+        return 0;
+    }
+
+    private static String sanitizeVersion(String version) {
+        if (version == null) return "0.0.0";
+        Pattern pattern = Pattern.compile("([0-9]+\\.[0-9]+\\.[0-9]+)");
+        Matcher matcher = pattern.matcher(version);
+        return matcher.find() ? matcher.group(1) : "0.0.0"; // Extracts only major.minor.patch
+    }
+}

--- a/src/main/java/com/cx/plugin/cli/utils/VersionChecker.java
+++ b/src/main/java/com/cx/plugin/cli/utils/VersionChecker.java
@@ -45,9 +45,11 @@ public class VersionChecker {
 
     private static String fetchLatestVersion() throws IOException {
         URL url = new URL(API_URL);
+        HttpURLConnection.setFollowRedirects(false);
         HttpURLConnection conn = (HttpURLConnection) url.openConnection();
         conn.setRequestMethod("GET");
         conn.setRequestProperty("Accept", "application/vnd.github.v3+json");
+        conn.setConnectTimeout(5000);
 
         int responseCode = conn.getResponseCode();
         if (responseCode != 200) {


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](https://github.com/checkmarx-ltd/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/checkmarx-ltd/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

> Currently, the program always outputs the CLI version on each run. These changes replace that section with an automatic version check using the tags in this repository:

Running the latest version:

```
[2025-01-30T11:44:44,879 INFO ] -----------------------------------------------------------------------------------------
[2025-01-30T11:44:44,880 INFO ] CxConsole Configuration:
[2025-01-30T11:44:44,880 INFO ] --------------------
[2025-01-30T11:44:45,418 INFO ] Current version: 1.1.36
[2025-01-30T11:44:45,418 INFO ] Latest version: 1.1.36
[2025-01-30T11:44:45,419 INFO ] You are running the latest version.
[2025-01-30T11:44:45,419 INFO ] --------------------
```

Running an outdated version:

```
[2025-01-30T11:22:15,200 INFO ] -----------------------------------------------------------------------------------------
[2025-01-30T11:22:15,230 INFO ] CxConsole Configuration:
[2025-01-30T11:22:16,230 INFO ] --------------------
[2025-01-30T11:22:16,600 INFO ] Current version: 1.1.33
[2025-01-30T11:22:16,600 INFO ] Latest version: 1.1.36
[2025-01-30T11:22:16,602 INFO ] A new version is available: 1.1.36. Please visit checkmarx.com/plugins and download the latest version.
[2025-01-30T11:22:16,602 INFO ] --------------------
```

This allows the users to have more context on the version they're running and then act accordingly to ensure they're up to date with the latest changes.

### References

> N/A

### Testing

> This was tested building the latest current version, 1.1.36, and also the previous one, 1.1.33. The plugin reacts correctly according to these two scenarios.
> A connection timeout (5000 ms) was added to ensure pipelines don't hang unnecessarily on this arguably non-critical step.
> Given that are companies that block access to GitHub, this was also tested. When access to GH is blocked, the error gets logged out properly without breaking the build.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentaiton is a Wiki Update, please indicate desired changes within PR MD Comment*
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used
