### PR TITLE
Configure logger levels for external libraries

### DIFF
--- a/log4j2.xml
+++ b/log4j2.xml
@@ -22,14 +22,41 @@
     </Appenders>
 
     <Loggers>
-        <Logger name="org.apache.http" level="WARN"/>
-        <Logger name="org.apache.cxf" level="ERROR"/>
-        <Logger name="org.springframework" level="ERROR"/>
-        <Logger name="org.whitesource.agent" level="ERROR"/>
-
-        <Root level="TRACE">
-            <AppenderRef ref="Routing" level="${sys:logLevel}"/>
-            <AppenderRef ref="CA" level="${sys:logLevel:-INFO}"/>
+        <Logger name="org.apache.http" level="WARN" additivity="false">
+            <AppenderRef ref="Routing"/>
+            <AppenderRef ref="CA"/>
+        </Logger>
+        <Logger name="org.apache.http.wire" level="WARN" additivity="false">
+            <AppenderRef ref="Routing"/>
+            <AppenderRef ref="CA"/>
+        </Logger>
+        <Logger name="org.apache.http.headers" level="WARN" additivity="false">
+            <AppenderRef ref="Routing"/>
+            <AppenderRef ref="CA"/>
+        </Logger>
+        <Logger name="org.apache.cxf" level="ERROR" additivity="false">
+            <AppenderRef ref="Routing"/>
+            <AppenderRef ref="CA"/>
+        </Logger>
+        <Logger name="org.springframework" level="ERROR" additivity="false">
+            <AppenderRef ref="Routing"/>
+            <AppenderRef ref="CA"/>
+        </Logger>
+        <Logger name="org.whitesource.agent" level="ERROR" additivity="false">
+            <AppenderRef ref="Routing"/>
+            <AppenderRef ref="CA"/>
+        </Logger>
+        <Logger name="com.cx" level="${sys:logLevel:-INFO}" additivity="false">
+            <AppenderRef ref="Routing"/>
+            <AppenderRef ref="CA"/>
+        </Logger>
+        <Logger name="com.checkmarx.configprovider" level="${sys:logLevel:-INFO}" additivity="false">
+            <AppenderRef ref="Routing"/>
+            <AppenderRef ref="CA"/>
+        </Logger>
+        <Root level="INFO">
+            <AppenderRef ref="Routing"/>
+            <AppenderRef ref="CA"/>
         </Root>
     </Loggers>
 </Configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -392,6 +392,12 @@
 			<artifactId>netty-common</artifactId>
 			<version>4.1.118.Final</version>
 		</dependency>
+        <!-- SLF4J API - Required for external libraries that use SLF4J -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.36</version>
+        </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-to-slf4j -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
@@ -409,6 +415,12 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
             <version>2.17.1</version>
+        </dependency>
+        <!-- JCL to SLF4J bridge for Apache Commons Logging -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <version>1.7.36</version>
         </dependency>
         <dependency>
     		<groupId>org.eclipse.jgit</groupId>

--- a/src/main/java/com/cx/plugin/cli/CxConsoleLauncher.java
+++ b/src/main/java/com/cx/plugin/cli/CxConsoleLauncher.java
@@ -48,8 +48,19 @@ public class CxConsoleLauncher {
     static {
         try {
             String log4jConfigFile = System.getProperty("user.dir") + File.separator + "log4j2.xml";
-            ConfigurationSource source = new ConfigurationSource(new FileInputStream(log4jConfigFile));
-            Configurator.initialize(null, source);
+            File configFile = new File(log4jConfigFile);
+            if (configFile.exists() && configFile.length() > 0) {
+                try {
+                    javax.xml.parsers.DocumentBuilderFactory factory = javax.xml.parsers.DocumentBuilderFactory.newInstance();
+                    javax.xml.parsers.DocumentBuilder builder = factory.newDocumentBuilder();
+                    builder.parse(configFile);
+                    Configurator.reconfigure(configFile.toURI());
+                } catch (Exception validationException) {
+                    System.out.println("Failed to use external log config file");
+                }
+            } else {
+                System.out.println("Failed to use external log config file");
+            }
         } catch (Exception e) {
             System.out.println("Failed to use external log config file");
         }

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -22,14 +22,41 @@
     </Appenders>
 
     <Loggers>
-        <Logger name="org.apache.http" level="WARN"/>
-        <Logger name="org.apache.cxf" level="ERROR"/>
-        <Logger name="org.springframework" level="ERROR"/>
-        <Logger name="org.whitesource.agent" level="ERROR"/>
-
-        <Root level="TRACE">
-            <AppenderRef ref="Routing" level="${sys:logLevel}"/>
-            <AppenderRef ref="CA" level="${sys:logLevel:-INFO}"/>
+        <Logger name="org.apache.http" level="WARN" additivity="false">
+            <AppenderRef ref="Routing"/>
+            <AppenderRef ref="CA"/>
+        </Logger>
+        <Logger name="org.apache.http.wire" level="WARN" additivity="false">
+            <AppenderRef ref="Routing"/>
+            <AppenderRef ref="CA"/>
+        </Logger>
+        <Logger name="org.apache.http.headers" level="WARN" additivity="false">
+            <AppenderRef ref="Routing"/>
+            <AppenderRef ref="CA"/>
+        </Logger>
+        <Logger name="org.apache.cxf" level="ERROR" additivity="false">
+            <AppenderRef ref="Routing"/>
+            <AppenderRef ref="CA"/>
+        </Logger>
+        <Logger name="org.springframework" level="ERROR" additivity="false">
+            <AppenderRef ref="Routing"/>
+            <AppenderRef ref="CA"/>
+        </Logger>
+        <Logger name="org.whitesource.agent" level="ERROR" additivity="false">
+            <AppenderRef ref="Routing"/>
+            <AppenderRef ref="CA"/>
+        </Logger>
+        <Logger name="com.cx" level="${sys:logLevel:-INFO}" additivity="false">
+            <AppenderRef ref="Routing"/>
+            <AppenderRef ref="CA"/>
+        </Logger>
+        <Logger name="com.checkmarx.configprovider" level="${sys:logLevel:-INFO}" additivity="false">
+            <AppenderRef ref="Routing"/>
+            <AppenderRef ref="CA"/>
+        </Logger>
+        <Root level="INFO">
+            <AppenderRef ref="Routing"/>
+            <AppenderRef ref="CA"/>
         </Root>
     </Loggers>
 </Configuration>


### PR DESCRIPTION
 -External log4j2.xml changes are now applied at runtime 
- Library log levels can be controlled by modifying external config file 
- Falls back to classpath config if external file is invalid/missing 