### PR TITLE
PLUG-2828 - Updated dependencies to fix vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.cx.plugin</groupId>
     <artifactId>CxConsolePlugin</artifactId>
-    <version>1.1.40</version>
+    <version>1.1.41</version>
     <packaging>jar</packaging>
 
     <repositories>
@@ -201,7 +201,7 @@
         <dependency>
 			<groupId>io.vertx</groupId>
 			<artifactId>vertx-core</artifactId>
-			<version>4.5.9</version>
+			<version>4.5.24</version>
 			<exclusions>
 				<exclusion>
 					<groupId>io.netty</groupId>
@@ -256,7 +256,7 @@
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
 			<artifactId>bcprov-jdk18on</artifactId>
-			<version>1.79</version>
+			<version>1.81</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>
@@ -266,12 +266,12 @@
 		<dependency>
 			<groupId>io.netty</groupId>
 			<artifactId>netty-codec-http</artifactId>
-			<version>4.2.5.Final</version>
+			<version>4.2.10.Final</version>
 		</dependency>
 		<dependency>
 			<groupId>org.mozilla</groupId>
 			<artifactId>rhino</artifactId>
-			<version>1.7.15</version>
+			<version>1.7.15.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.iq80.snappy</groupId>
@@ -355,7 +355,7 @@
         <dependency>
 			<groupId>io.netty</groupId>
 			<artifactId>netty-handler</artifactId>
-			<version>4.1.118.Final</version>
+			<version>4.2.0.Final</version>
 		</dependency>
 		<dependency>
 			<groupId>io.netty</groupId>
@@ -375,7 +375,7 @@
 		<dependency>
 			<groupId>io.netty</groupId>
 			<artifactId>netty-codec-http2</artifactId>
-			<version>4.2.5.Final</version>
+			<version>4.2.10.Final</version>
 		</dependency>
 		<dependency>
 			<groupId>io.netty</groupId>
@@ -396,19 +396,19 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.17.1</version>
+            <version>2.25.3</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-core -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.17.1</version>
+            <version>2.25.3</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-api -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.17.1</version>
+            <version>2.25.3</version>
         </dependency>
         <dependency>
     		<groupId>org.eclipse.jgit</groupId>

--- a/src/main/java/com/cx/plugin/cli/CxConsoleLauncher.java
+++ b/src/main/java/com/cx/plugin/cli/CxConsoleLauncher.java
@@ -134,7 +134,7 @@ public class CxConsoleLauncher {
 
         validateScanParameters(cxScanConfig);
 
-        org.slf4j.Logger logger = new Log4jLoggerFactory().getLogger(log.getName());
+        org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(log.getName());
 
         CxSastConnectionProvider connectionProvider = new CxSastConnectionProvider(cxScanConfig, logger);
 


### PR DESCRIPTION
Threat level 8 -> https://github.com/advisories/GHSA-h5fg-jpgr-rv9c -> CVSS Score 7.5 -> package: io.vertx : vertx-web : 4.5.8
NVD - https://github.com/advisories/GHSA-h5fg-jpgr-rv9c
Status: Not in CLI, not in cx_client_common, FP

Threat level 8 -> https://github.com/advisories/GHSA-3p8m-j85q-pgmj -> CVSS Score 7.5 -> package: io.netty : netty-codec : 4.1.118.Final
NVD - https://github.com/advisories/GHSA-3p8m-j85q-pgmj
Status: Not in CLI, not in cx_client_common, FP

Threat level 7 -> sonatype-2025-001911 -> CVSS Score 6.9 -> package: org.bouncycastle : bcprov-jdk18on : 1.79
Status: UPGRADED TO 1.81 -> https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk18on/1.81

Threat level 7 -> https://github.com/advisories/GHSA-84h7-rjj3-6jx4 -> CVSS Score 6.5 -> package: io.netty : netty-codec-http : 4.2.5.Final
NVD - https://github.com/advisories/GHSA-84h7-rjj3-6jx4
Status: UPGRADED TO 4.2.10.FINAL -> https://mvnrepository.com/artifact/io.netty/netty-codec-http/4.2.10.Final

Threat level 7 -> sonatype-2020-0026 -> CVSS Score 6.5 -> package: io.netty : netty-handler : 4.1.118.Final 
https://www.cve.org/CVERecord?id=CVE-2025-8916 / https://www.cve.org/CVERecord?id=CVE-2025-58057
Status: UPGRADED TO 4.2.0.FINAL -> https://mvnrepository.com/artifact/io.netty/netty-handler/4.2.0.Final

Threat level 7 -> https://github.com/advisories/GHSA-45p5-v273-3qqr -> CVSS Score 6.4 -> package: io.vertx : vertx-web : 4.5.8
NVD - https://github.com/advisories/GHSA-45p5-v273-3qqr
Status: Not in CLI, not in cx_client_common, FP

Threat level 7 -> https://github.com/advisories/GHSA-cphf-4846-3xx9 -> CVSS Score 5,3 -> package: io.vertx : vertx-core : 4.5.9
NVD - https://github.com/advisories/GHSA-cphf-4846-3xx9
Status: UPGRADED TO 4.5.24, but all versions have vulnerabilitites from dependencies -> https://mvnrepository.com/artifact/io.vertx/vertx-core/4.5.24

Threat level 7 -> https://github.com/advisories/GHSA-vc5p-v9hr-52mj -> CVSS Score 4,8 -> package: org.apache.logging.log4j : log4j-core : 2.17.1
NVD - https://github.com/advisories/GHSA-vc5p-v9hr-52mj
Status: UPGRADED TO 2.25.3 -> https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-core/2.25.3

Threat level 3 -> https://github.com/advisories/GHSA-3w8q-xq97-5j7x -> CVSS Score 2,7 -> package: org.mozilla : rhino : 1.7.15
NVD - https://github.com/advisories/GHSA-3w8q-xq97-5j7x .
Status: UPGRADED TO 1.17.15.1 -> https://mvnrepository.com/artifact/org.mozilla/rhino/1.7.15.1

Testing
Did basic testing with scans, all seems good.